### PR TITLE
update settings of favonia/cloudflare-ddns

### DIFF
--- a/roles/public_hosting/tasks/cf-ddns.yaml
+++ b/roles/public_hosting/tasks/cf-ddns.yaml
@@ -7,15 +7,10 @@
     cleanup: false
     detach: true
     restart_policy: unless-stopped
-    capabilities:
-      - SETUID
-      - SETGID
+    user: "{{ username_uid }}:{{ username_guid }}"
     network_mode: host
     env:
       TZ: "{{ time_zone }}"
-      PUID: "{{ username_uid }}"
-      PGUID: "{{ username_guid }}"
-      PGID: "{{ username_guid }}"
       PROXIED: "true"
       CF_API_TOKEN: "{{ cf_dns_token }}"
       DOMAINS: "{{ cf_ddns_domains | join(',') }}"


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.